### PR TITLE
ADD Github Automatic Build

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -42,5 +42,5 @@ jobs:
     - name: Upload artifact
       uses: actions/upload-artifact@v4
       with:
-        name: parsi-analyzer-zip
+        name: ${{ env.ZIP_FILE_NAME }}
         path: ${{ env.ZIP_FILE }}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,36 @@
+# This workflow will build a Java project with Maven, and cache/restore any dependencies to improve the workflow execution time
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-maven
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Java CI with Maven
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        cache: maven
+    - name: Build with Maven
+      #run: mvn -B package --file pom.xml
+      run: mvn clean package
+
+    # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
+    - name: Update dependency graph
+      uses: advanced-security/maven-dependency-submission-action@571e99aab1055c2e71a1e2309b9691de18d6b7d6

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -24,15 +24,23 @@ jobs:
     - name: Build with Maven
       run: mvn clean package
 
+    - name: Find the Generated ZIP File
+      run: |
+        ZIP_FILE=$(find target/releases/ -name "*.zip" | head -n 1)
+        echo "ZIP_FILE=$ZIP_FILE" >> $GITHUB_ENV
+        echo "ZIP_FILE_NAME=$(basename $ZIP_FILE)" >> $GITHUB_ENV
+
     - name: Create GitHub Release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         TAG_NAME=v1.0.${{ github.run_number }}
-        gh release create $TAG_NAME target/releases/ParsiAnalyzer-1.0-SNAPSHOT.zip --title "Release $TAG_NAME" --notes "Automated release from GitHub Actions"
+        gh release create $TAG_NAME ${{ env.ZIP_FILE }} \
+          --title "Release $TAG_NAME" \
+          --notes "Automated release from GitHub Actions.\n\nGenerated ZIP file: **${{ env.ZIP_FILE_NAME }}**"
 
     - name: Upload artifact
       uses: actions/upload-artifact@v4
       with:
         name: parsi-analyzer-zip
-        path: target/releases/ParsiAnalyzer-1.0-SNAPSHOT.zip
+        path: ${{ env.ZIP_FILE }}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -30,7 +30,3 @@ jobs:
     - name: Build with Maven
       #run: mvn -B package --file pom.xml
       run: mvn clean package
-
-    # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
-    - name: Update dependency graph
-      uses: advanced-security/maven-dependency-submission-action@571e99aab1055c2e71a1e2309b9691de18d6b7d6

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,11 +1,3 @@
-# This workflow will build a Java project with Maven, and cache/restore any dependencies to improve the workflow execution time
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-maven
-
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-
 name: Java CI with Maven
 
 on:
@@ -21,12 +13,26 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+
     - name: Set up JDK 17
       uses: actions/setup-java@v4
       with:
         java-version: '17'
         distribution: 'temurin'
         cache: maven
+
     - name: Build with Maven
-      #run: mvn -B package --file pom.xml
       run: mvn clean package
+
+    - name: Create GitHub Release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        TAG_NAME=v1.0.${{ github.run_number }}
+        gh release create $TAG_NAME target/releases/ParsiAnalyzer-1.0-SNAPSHOT.zip --title "Release $TAG_NAME" --notes "Automated release from GitHub Actions"
+
+    - name: Upload artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: parsi-analyzer-zip
+        path: target/releases/ParsiAnalyzer-1.0-SNAPSHOT.zip

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ir.ac.sbu</groupId>
     <artifactId>ParsiAnalyzer</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>BUILD-8.16.1</version>
 
     <build>
         <resources>
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>org.elasticsearch</groupId>
             <artifactId>elasticsearch</artifactId>
-            <version>8.13.0</version>
+            <version>8.16.1</version>
             <scope>provided</scope>
         </dependency>
 

--- a/src/main/resources/plugin-descriptor.properties
+++ b/src/main/resources/plugin-descriptor.properties
@@ -3,4 +3,4 @@ version=1.0
 name=ParsiAnalyzer
 classname=org.elasticsearch.analyzer.ParsiAnalyzerPlugin
 java.version=1.8
-elasticsearch.version=8.13.0
+elasticsearch.version=8.16.1


### PR DESCRIPTION
### **Pull Request Message**  

**Title:** `ADD Github Automatic Build`  

**Description:**  
This PR introduces **GitHub Actions for automatic builds** to the `ParsiAnalyzer` repository. The workflow is triggered on `push` and `pull_request` events for the `master` branch and performs the following steps:  

✅ **Checkout repository**  
✅ **Set up JDK 17** using Temurin  
✅ **Cache Maven dependencies** to speed up builds  
✅ **Build the project using Maven** (`mvn clean package`)  
✅ **Generate a ZIP artifact** containing the build output  
✅ **(Optional) Upload release asset to GitHub Releases**  

### **Why?**  
- Automates the build process to ensure code integrity  
- Provides faster feedback on PRs and commits  
- Simplifies deployment by generating a packaged ZIP  

### **Next Steps (Optional Enhancements)**  
- Add tests and automate test execution  
- Deploy artifacts to a package registry (e.g., GitHub Packages)  
- Notify developers of build status via email or Slack  

Let me know if you have any suggestions! 🚀